### PR TITLE
feat: redesign 404 error page with helpful recovery actions

### DIFF
--- a/app/error.vue
+++ b/app/error.vue
@@ -1,19 +1,30 @@
 <script setup lang="ts">
 import type { NuxtError } from '#app'
 
-defineProps<{
+const props = defineProps<{
   error: NuxtError
 }>()
 
-useHead({
-  htmlAttrs: {
-    lang: 'en'
+const router = useRouter()
+const route = useRoute()
+
+const isNotFound = computed(() => Number(props.error?.statusCode) === 404)
+const statusCode = computed(() => Number(props.error?.statusCode) || 500)
+const headline = computed(() => isNotFound.value ? 'Page not found' : `Error ${statusCode.value}`)
+const description = computed(() => {
+  if (isNotFound.value) {
+    return `We couldn't find anything at "${route.path}". The page may have moved, been renamed, or never existed.`
   }
+  return props.error?.statusMessage || 'Something went wrong while loading this page.'
+})
+
+useHead({
+  htmlAttrs: { lang: 'en' }
 })
 
 useSeoMeta({
-  title: 'Page not found',
-  description: 'We are sorry but this page could not be found.'
+  title: headline.value,
+  description: description.value
 })
 
 const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('docs'))
@@ -22,13 +33,117 @@ const { data: files } = useLazyAsyncData('search', () => queryCollectionSearchSe
 })
 
 provide('navigation', navigation)
+
+const popularLinks = [
+  { label: 'Getting started', to: '/getting-started/installation', icon: 'i-lucide-rocket' },
+  { label: 'Quick start', to: '/getting-started/quick-start', icon: 'i-lucide-zap' },
+  { label: 'API reference', to: '/api-reference', icon: 'i-lucide-book-open' },
+  { label: 'Integration guides', to: '/integration-guides', icon: 'i-lucide-puzzle' }
+]
+
+function goHome() {
+  return router.push('/')
+}
+
+function goBack() {
+  if (window.history.length > 1) {
+    router.back()
+  } else {
+    router.push('/')
+  }
+}
 </script>
 
 <template>
   <UApp>
     <AppHeader />
 
-    <UError :error="error" />
+    <UMain>
+      <UContainer class="py-12 sm:py-20">
+        <div class="mx-auto max-w-2xl text-center">
+          <p
+            data-testid="error-status"
+            class="text-sm font-mono uppercase tracking-wide text-primary"
+          >
+            Error {{ statusCode }}
+          </p>
+          <h1
+            data-testid="error-headline"
+            class="mt-2 text-3xl sm:text-4xl font-bold text-highlighted"
+          >
+            {{ headline }}
+          </h1>
+          <p
+            data-testid="error-description"
+            class="mt-4 text-base sm:text-lg text-muted"
+          >
+            {{ description }}
+          </p>
+
+          <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
+            <UButton
+              data-testid="error-home"
+              icon="i-lucide-home"
+              size="lg"
+              @click="goHome"
+            >
+              Back to docs home
+            </UButton>
+            <UButton
+              data-testid="error-back"
+              icon="i-lucide-arrow-left"
+              variant="ghost"
+              size="lg"
+              @click="goBack"
+            >
+              Go back
+            </UButton>
+          </div>
+
+          <div
+            v-if="isNotFound"
+            class="mt-12 text-left"
+          >
+            <h2 class="text-sm font-semibold uppercase tracking-wide text-muted">
+              Popular pages
+            </h2>
+            <ul
+              data-testid="error-popular"
+              class="mt-4 grid gap-3 sm:grid-cols-2"
+            >
+              <li
+                v-for="link in popularLinks"
+                :key="link.to"
+              >
+                <ULink
+                  :to="link.to"
+                  class="flex items-center gap-3 rounded-md border border-default p-3 hover:bg-elevated/50 transition-colors"
+                >
+                  <UIcon
+                    :name="link.icon"
+                    class="h-5 w-5 text-primary"
+                  />
+                  <span class="text-sm font-medium">{{ link.label }}</span>
+                </ULink>
+              </li>
+            </ul>
+
+            <p class="mt-6 text-sm text-muted">
+              Tip: press
+              <kbd class="px-1.5 py-0.5 rounded border border-default font-mono text-xs">⌘</kbd>
+              <kbd class="px-1.5 py-0.5 rounded border border-default font-mono text-xs">K</kbd>
+              to search the docs, or
+              <ULink
+                to="https://github.com/ZunoKit/zuno-marketplace-docs/issues/new"
+                target="_blank"
+                class="underline"
+              >open an issue</ULink>
+              if you think this is a bug.
+            </p>
+          </div>
+        </div>
+      </UContainer>
+    </UMain>
 
     <AppFooter />
 


### PR DESCRIPTION
## Summary

The previous `app/error.vue` just rendered the default `<UError>` with no context, navigation aids, or recovery actions. If a user landed on a broken URL they would see a blank-ish error page and have to figure out where to go on their own.

This rewrites `error.vue` as a proper docs-themed error page with:

- **Status code + headline + descriptive copy** that references the path the user tried to visit (`route.path`)
- **Primary actions**: 'Back to docs home' and 'Go back' (uses `history.back()` when there's history, falls back to `/`)
- **Popular pages grid**: Getting started, Quick start, API reference, Integration guides — so visitors can pivot quickly
- **Tip line** with the `Cmd/Ctrl + K` shortcut for the in-app search
- **Issue-tracker link** so users can flag broken links

Keeps the existing `AppHeader`, `AppFooter` and `LazyUContentSearch` ClientOnly wiring intact. Generic non-404 errors fall back to a sensible generic state (e.g. 500s still show a meaningful headline / description).

`data-testid` attributes are added on each state for future Playwright tests.

## Test plan

```bash
pnpm install
pnpm lint        # passes
pnpm dev         # visit /this-does-not-exist to see the new page
```

No new dependencies. No changes outside `app/error.vue`.

---
Requested by: Trần Quang Đãng (tranquangdang21@gmail.com)
Devin session: https://app.devin.ai/sessions/79196eb702e540bcb7f25327328ad45d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error pages now display customized content and SEO information based on the specific error type
  * Added "Popular pages" section on 404 error pages to help users find relevant content
  * Integrated search functionality directly within error pages
  * Enhanced navigation with "Back to docs home" and "Go back" actions for better user guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zunokit/zuno-marketplace-docs/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->